### PR TITLE
Bump cargo deps

### DIFF
--- a/fieldmask/Cargo.toml
+++ b/fieldmask/Cargo.toml
@@ -12,7 +12,7 @@ include = [
 prost-integration = ["prost", "fieldmask_derive/prost"]
 
 [dependencies]
-derive_more = "0.99.11"
+derive_more = "0.99.17"
 fieldmask_derive = { version = "0.0.1", path = "../fieldmask_derive" }
-prost = { version = "0.6.1", optional = true }
-thiserror = "1.0.22"
+prost = { version = "0.11.9", optional = true }
+thiserror = "1.0.40"

--- a/fieldmask_derive/Cargo.toml
+++ b/fieldmask_derive/Cargo.toml
@@ -16,6 +16,6 @@ prost = []
 
 [dependencies]
 Inflector = "0.11.4"
-proc-macro2 = "1.0.24"
-quote = "1.0.7"
-syn = "1.0.54"
+proc-macro2 = "1.0.60"
+quote = "1.0.28"
+syn = "1.0.109"


### PR DESCRIPTION
- Bump prost to the latest minor version (required to use prost 0.11.x with this crate)
- Bump patch versions of everything else