### PR TITLE
improve prost support

### DIFF
--- a/fieldmask/src/maskable.rs
+++ b/fieldmask/src/maskable.rs
@@ -150,6 +150,9 @@ maskable!(usize);
 
 maskable!(String);
 
+#[cfg(feature = "prost")]
+maskable!(prost::bytes::Bytes);
+
 impl<T> Maskable for Vec<T> {
     type Mask = bool;
 

--- a/fieldmask/src/maskable.rs
+++ b/fieldmask/src/maskable.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -174,6 +176,34 @@ impl<T> Maskable for Vec<T> {
 }
 
 impl<T> SelfMaskable for Vec<T> {
+    fn apply_mask(&mut self, other: Self, mask: Self::Mask) {
+        if mask {
+            *self = other;
+        }
+    }
+}
+
+impl<K, V> Maskable for HashMap<K, V> {
+    type Mask = bool;
+
+    fn try_bitor_assign_mask(
+        mask: &mut Self::Mask,
+        field_mask_segs: &[&str],
+    ) -> Result<(), DeserializeMaskError> {
+        if field_mask_segs.len() == 0 {
+            *mask = true;
+            Ok(())
+        } else {
+            Err(DeserializeMaskError {
+                type_str: "HashMap",
+                field: field_mask_segs[0].into(),
+                depth: 0,
+            })
+        }
+    }
+}
+
+impl<K, V> SelfMaskable for HashMap<K, V> {
     fn apply_mask(&mut self, other: Self, mask: Self::Mask) {
         if mask {
             *self = other;

--- a/fieldmask/tests/full_example.rs
+++ b/fieldmask/tests/full_example.rs
@@ -9,6 +9,7 @@ struct Parent {
     child_2: Child,
     #[fieldmask(flatten)]
     one_of_field: Option<OneOfField>,
+    unit_field: UnitField,
 }
 
 #[derive(Debug, PartialEq, Maskable)]
@@ -21,6 +22,12 @@ struct Child {
 enum OneOfField {
     VariantOne(String),
     VariantTwo(u32),
+}
+
+#[derive(Debug, PartialEq, Maskable)]
+enum UnitField {
+    One = 1,
+    Two = 2,
 }
 
 impl Default for OneOfField {
@@ -42,6 +49,7 @@ fn case_1() {
             field_two: 2,
         },
         one_of_field: Some(OneOfField::VariantOne("variant one".into())),
+        unit_field: UnitField::One,
     };
     let src_struct = Parent {
         primitive: "updated string".into(),
@@ -54,6 +62,7 @@ fn case_1() {
             field_two: 20,
         },
         one_of_field: Some(OneOfField::VariantTwo(50)),
+        unit_field: UnitField::Two,
     };
 
     let expected_struct = Parent {
@@ -67,6 +76,7 @@ fn case_1() {
             field_two: 20,
         },
         one_of_field: Some(OneOfField::VariantTwo(50)),
+        unit_field: UnitField::Two,
     };
 
     FieldMask::try_from(FieldMaskInput(
@@ -75,6 +85,7 @@ fn case_1() {
             "child_1.field_two",
             "child_2", // if child properties are not specified, all properties are included.
             "variant_two", // if a field is marked with `flatten`, its properties are merged with its parents properties.
+            "unit_field",
         ]
         .into_iter(),
     ))


### PR DESCRIPTION
- Add support for prost Bytes
- Add basic support for prost HashMaps (this does not support masking into string-keyed maps and just treats them like a scalar value that can be masked)
- Add support for deriving against prost enums with discriminants, which behave like scalar values for the purposes of masking